### PR TITLE
update SimpleInjector Nuget Package 4.0.6 to 4.0.7

### DIFF
--- a/src/HangFire.SimpleInjector.Tests/HangFire.SimpleInjector.Tests.csproj
+++ b/src/HangFire.SimpleInjector.Tests/HangFire.SimpleInjector.Tests.csproj
@@ -49,8 +49,8 @@
     <Reference Include="Owin">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
-    <Reference Include="SimpleInjector, Version=4.0.6.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
-      <HintPath>..\packages\SimpleInjector.4.0.6\lib\net45\SimpleInjector.dll</HintPath>
+    <Reference Include="SimpleInjector, Version=4.0.7.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\packages\SimpleInjector.4.0.7\lib\net45\SimpleInjector.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/HangFire.SimpleInjector.Tests/packages.config
+++ b/src/HangFire.SimpleInjector.Tests/packages.config
@@ -3,5 +3,5 @@
   <package id="Hangfire.Core" version="1.6.12" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
-  <package id="SimpleInjector" version="4.0.6" targetFramework="net45" />
+  <package id="SimpleInjector" version="4.0.7" targetFramework="net45" />
 </packages>

--- a/src/HangFire.SimpleInjector/HangFire.SimpleInjector.csproj
+++ b/src/HangFire.SimpleInjector/HangFire.SimpleInjector.csproj
@@ -44,8 +44,8 @@
     <Reference Include="Owin">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
-    <Reference Include="SimpleInjector, Version=4.0.6.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
-      <HintPath>..\packages\SimpleInjector.4.0.6\lib\net45\SimpleInjector.dll</HintPath>
+    <Reference Include="SimpleInjector, Version=4.0.7.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\packages\SimpleInjector.4.0.7\lib\net45\SimpleInjector.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/HangFire.SimpleInjector/packages.config
+++ b/src/HangFire.SimpleInjector/packages.config
@@ -4,5 +4,5 @@
   <package id="Hangfire.Core" version="1.6.12" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
-  <package id="SimpleInjector" version="4.0.6" targetFramework="net45" />
+  <package id="SimpleInjector" version="4.0.7" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I received error '**System.NotSupportedException: GetCurrentExecutionContextScope has been deprecated. Please use Lifestyle.Scoped.GetCurrentScope(Container) instead.**' when use 4.0.7 SimpleInjector version in my project.

I updated 4.0.6 to 4.0.7 SimpleInjector nuget in HangFire.SimpleInjector and now it's working.